### PR TITLE
Shorten Android Web View Sample Package name to fix debugging issues.

### DIFF
--- a/src/Samples/Basic/OpenMVVM.Samples.Basic.WebView.Android/Properties/AndroidManifest.xml
+++ b/src/Samples/Basic/OpenMVVM.Samples.Basic.WebView.Android/Properties/AndroidManifest.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="OpenMVVM.Samples.Basic.WebView.Android.OpenMVVM.Samples.Basic.WebView.Android" android:versionCode="1" android:versionName="1.0">
-  <uses-sdk android:minSdkVersion="16" />
-  <application android:label="OpenMVVM.Samples.Basic.WebView.Android"></application>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="OpenMVVM.Samples.Basic.WebView.Android" android:versionCode="1" android:versionName="1.0" android:installLocation="auto">
+	<uses-sdk android:minSdkVersion="16" />
+	<application android:label="OpenMVVM.Samples.Basic.WebView.Android"></application>
 </manifest>


### PR DESCRIPTION
I have fixed the issue with debugger cannot attach to Android emulator. The issue was Android Manifest package name being too long.